### PR TITLE
osx fuse is required on os x.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ The files of the torrent should be mounted there now and you should be able to d
 
 ![MIND BLOWN](http://i.imgur.com/C4buo.gif)
 
+## Troubleshoot
+
+You should install OS X Fuse on OS X systems:
+
+	brew install osxfuse
+
 ## License
 
 MIT


### PR DESCRIPTION
OS X needs osxfuse. If not, gyp will fail while installing fuse4js.
